### PR TITLE
Added minimum iOS version to SPM description

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "ScrollStackController",
+    platforms: [.iOS(.v11)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ import PackageDescription
 
   let package = Package(name: "YourPackage",
     dependencies: [
-      .Package(url: "https://github.com/malcommac/SwiftLocation.git", majorVersion: 0),
+      .Package(url: "https://github.com/malcommac/ScrollStackController.git", majorVersion: 0),
     ]
   )
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="banner.png" width=300px alt="ScrollStackController" title="ScrollStackController">
 </p>
 
-<p align="center"><strong>Easy scrollable complex layouts in UIKit</strong></p>
+<p align="center"><strong>Easy scrollable layouts in UIKit</strong></p>
 
 Create complex scrollable layout using UIViewControllers or plain UIViews and simplify your code!
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you are using SwiftLocation or any other of my creations please consider the 
 - [**Become a Sponsor**](https://github.com/sponsors/malcommac)
 
 - [Follow Me](https://github.com/malcommac)
-- 
+
 <a name="index"/>
 
 ## Table of Contents
@@ -693,7 +693,17 @@ You should look at it in order to implement your own layout, create dynamically 
 pod 'ScrollStackController'
 ```
 
-It also supports `Swift Package Maneger` aka SPM.
+It also supports `Swift Package Maneger` aka SPM in your `Package.swift`:
+
+```sh
+import PackageDescription
+
+  let package = Package(name: "YourPackage",
+    dependencies: [
+      .Package(url: "https://github.com/malcommac/SwiftLocation.git", majorVersion: 0),
+    ]
+  )
+```
 
 [↑ Back To Top](#index)
 


### PR DESCRIPTION
Resolves this issue https://github.com/malcommac/ScrollStackController/issues/17

Tested within a project.

### What tests were performed?
* Added `ScrollStackController` as a Swift Package.
* Compiled project, which produced compiler errors, as detailed in the issue.
* Removed `ScrollStackController`, and added this fork, in which the solution is included.
* Compiled project, with no compiler errors.

