### PR TITLE
Fix: `ScrollStackControllerDelegate` methods calls

### DIFF
--- a/Sources/ScrollStackController/ScrollStack.swift
+++ b/Sources/ScrollStackController/ScrollStack.swift
@@ -860,6 +860,8 @@ open class ScrollStack: UIScrollView, UIScrollViewDelegate {
         return createRow(newRow, at: index, cellToRemove: cellToRemove, animated: animated, completion: completion)
     }
     
+    private var rowVisibilityChangesDispatchWorkItem: DispatchWorkItem?
+    
     /// Private implementation to add new row.
     private func createRow(_ newRow: ScrollStackRow, at index: Int,
                            cellToRemove: ScrollStackRow?,
@@ -878,7 +880,21 @@ open class ScrollStack: UIScrollView, UIScrollViewDelegate {
             }, completion: nil)
         }
         
-        scrollViewDidScroll(self)
+        if rowVisibilityChangesDispatchWorkItem == nil {
+            
+            rowVisibilityChangesDispatchWorkItem = DispatchWorkItem(block: { [weak self] in
+                if let stackDelegate = self?.stackDelegate {
+                    self?.dispatchRowsVisibilityChangesTo(stackDelegate)
+                }
+                
+                self?.rowVisibilityChangesDispatchWorkItem = nil
+            })
+            
+            /// Schedule a single `dispatchRowsVisibilityChangesTo(_:)` call.
+            ///
+            /// In this way, when rows are created inside a for-loop, the delegate is called only once after the `ScrollStack` has been fully layed out.
+            DispatchQueue.main.async(execute: rowVisibilityChangesDispatchWorkItem!)
+        }
         
         return newRow
     }
@@ -979,25 +995,27 @@ open class ScrollStack: UIScrollView, UIScrollViewDelegate {
     }
     
     private func dispatchRowsVisibilityChangesTo(_ delegate: ScrollStackControllerDelegate) {
-        delegate.scrollStackDidScroll(self, offset: contentOffset)
-        
         rows.enumerated().forEach { (idx, row) in
             let current = isRowVisible(index: idx)
-            if let previous = prevVisibilityState[row] {
-                switch (previous, current) {
-                case (.offscreen, .partial), // row will become invisible
-                     (.hidden, .partial),
-                     (.hidden, .entire):
-                    delegate.scrollStackRowDidBecomeVisible(self, row: row, index: idx, state: current)
-                    
-                case (.partial, .offscreen), // row will become visible
-                     (.partial, .hidden),
-                     (.entire, .hidden):
-                    delegate.scrollStackRowDidBecomeHidden(self, row: row, index: idx, state: current)
-
-                default:
-                    break
-                }
+            let previous = prevVisibilityState[row]
+            
+            switch (previous, current) {
+            case (.offscreen, .partial), // row will become visible
+                (nil, .entire),
+                (nil, .partial),
+                (.partial, .entire),
+                (.hidden, .partial),
+                (.hidden, .entire):
+                delegate.scrollStackRowDidBecomeVisible(self, row: row, index: idx, state: current)
+                
+            case (.partial, .offscreen), // row will become invisible
+                (.entire, .partial),
+                (.partial, .hidden),
+                (.entire, .hidden):
+                delegate.scrollStackRowDidBecomeHidden(self, row: row, index: idx, state: current)
+                
+            default:
+                break
             }
             
             // store previous state
@@ -1062,7 +1080,8 @@ open class ScrollStack: UIScrollView, UIScrollViewDelegate {
         guard let stackDelegate = stackDelegate else {
             return
         }
-        
+        stackDelegate.scrollStackDidScroll(self, offset: contentOffset)
+
         dispatchRowsVisibilityChangesTo(stackDelegate)
     }
     

--- a/Sources/ScrollStackController/ScrollStack.swift
+++ b/Sources/ScrollStackController/ScrollStack.swift
@@ -892,7 +892,7 @@ open class ScrollStack: UIScrollView, UIScrollViewDelegate {
             
             /// Schedule a single `dispatchRowsVisibilityChangesTo(_:)` call.
             ///
-            /// In this way, when rows are created inside a for-loop, the delegate is called only once after the `ScrollStack` has been fully layed out.
+            /// In this way, when rows are created inside a for-loop, the delegate is called only once after the `ScrollStack` has been fully laid out.
             DispatchQueue.main.async(execute: rowVisibilityChangesDispatchWorkItem!)
         }
         

--- a/Sources/ScrollStackController/ScrollStackRow.swift
+++ b/Sources/ScrollStackController/ScrollStackRow.swift
@@ -239,10 +239,11 @@ open class ScrollStackRow: UIView, UIGestureRecognizerDelegate {
         setNeedsUpdateConstraints()
     }
     
-    open override func layoutSubviews() {
-        super.layoutSubviews()
+    open override func updateConstraints() {
         // called the event to update the height of the row.
         askForCutomizedSizeOfContentView(animated: false)
+        
+        super.updateConstraints()
     }
     
     private func applyParentStackAttributes() {


### PR DESCRIPTION
This PR adresses an issue that causes calls to the `ScrollStackControllerDelegate` methods
- `scrollStackRowDidBecomeVisible(_:row:index:state:)`
- `scrollStackRowDidBecomeHidden(_:row:index:state:)`

before the completion of the `ScrollStack` layout process, when each rows still don't have a valid frame.

This can happen for example when a ViewController uses a `ScrollStack` as a subview and inserts rows in a for-loop inside its `viewDidLoad()` method.

Now these methods are called:
1. Only once after all the rows have been added and the `ScrollStack` has been fully laid out
2. When the user scrolls

---
A fix has been also made to the `dispatchRowsVisibilityChangesTo(_:)` `ScrollStack` method: it now takes into account new inserted rows which still don't have a previous visibility state.

---
Finally, the call to `askForCutomizedSizeOfContentView(animated:)` of `ScrollStackRow` has been moved back in the `updateConstraints()` method following the best practices described in [ModifyingConstraints](https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/AutolayoutPG/ModifyingConstraints.html):

> To batch a change, instead of making the change directly, call the [setNeedsUpdateConstraints](https://developer.apple.com/documentation/uikit/uiview/1622450-setneedsupdateconstraints) method on the view holding the constraint. Then, override the view’s [updateConstraints](https://developer.apple.com/documentation/uikit/uiview/1622512-updateconstraints) method to modify the affected constraints.
> Always call the superclasses implementation as the last step of your [updateConstraints](https://developer.apple.com/documentation/uikit/uiview/1622512-updateconstraints) method’s implementation.

This is necessary because we call `setNeedsUpdateConstraints()` in the `layoutUI()` method of `ScrollStackRow`.