### PR TITLE
Add visibility percentage to partial RowVisibility case

### DIFF
--- a/Sources/ScrollStackController/ScrollStack.swift
+++ b/Sources/ScrollStackController/ScrollStack.swift
@@ -794,7 +794,13 @@ open class ScrollStack: UIScrollView, UIScrollViewDelegate {
             return .offscreen
         }
         
-        return (bounds.contains(rowFrame) ? .entire : .partial)
+        if bounds.contains(rowFrame) {
+            return .entire
+        } else {
+            let intersection = bounds.intersection(rowFrame)
+            let intersectionPercentage = ((intersection.width * intersection.height) / (rowFrame.width * rowFrame.height)) * 100
+            return .partial(percentage: intersectionPercentage)
+        }
     }
     
     /// Remove passed row from stack view.

--- a/Sources/ScrollStackController/Support/ScrollStack+Protocols.swift
+++ b/Sources/ScrollStackController/Support/ScrollStack+Protocols.swift
@@ -177,9 +177,9 @@ public extension ScrollStack {
     /// - `hidden`: row is invisible and hidden.
     /// - `offscreen`: row is not hidden but currently offscreen due to scroll position.
     /// - `removed`: row is removed manually.
-    enum RowVisibility {
+    enum RowVisibility: Equatable {
         case hidden
-        case partial
+        case partial(percentage: Double)
         case entire
         case offscreen
         case removed


### PR DESCRIPTION
This pull request adds the functionality to expose the visibility percentage of a row. 

In the case where the visibility of the row is partial, the intersection of the frames between the row and the scrollstack is calculated and then transformed into a percentage.