### PR TITLE
Feat: Add `scrollStackDidEndScrollingAnimation(_ stackView: ScrollStack)` delegate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,33 +634,37 @@ Example:
 
 ```swift
 class ViewController: ScrollStackController, ScrollStackControllerDelegate {
-	
-  func viewDidLoad() {
-    super.viewDidLoad()
-    
-    self.scrollStack.stackDelegate = self
-  }
-	
-  func scrollStackDidScroll(_ stackView: ScrollStack, offset: CGPoint) {
-    // stack did scroll
-  }
-    
-  func scrollStackRowDidBecomeVisible(_ stackView: ScrollStack, row: ScrollStackRow, index: Int, state: ScrollStack.RowVisibility) {
-    // Row did become partially or entirely visible.
-  }
-    
-  func scrollStackRowDidBecomeHidden(_ stackView: ScrollStack, row: ScrollStackRow, index: Int, state: ScrollStack.RowVisibility) {
-    // Row did become partially or entirely invisible.
-  }
 
-  func scrollStackDidUpdateLayout(_ stackView: ScrollStack) {
-    // This function is called when layout is updated (added, removed, hide or show one or more rows).
-  }
+    func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.scrollStack.stackDelegate = self
+    }
 
-  func scrollStackContentSizeDidChange(_ stackView: ScrollStack, from oldValue: CGSize, to newValue: CGSize) {
-    // This function is called when content size of the stack did change (remove/add, hide/show rows).
-  }
+    func scrollStackDidScroll(_ stackView: ScrollStack, offset: CGPoint) {
+        // Stack did scroll
+    }
+    
+      
+    func scrollStackDidEndScrollingAnimation(_ stackView: ScrollStack) {
+        // Scrolling animation has ended
+    }
 
+    func scrollStackRowDidBecomeVisible(_ stackView: ScrollStack, row: ScrollStackRow, index: Int, state: ScrollStack.RowVisibility) {
+        // Row did become partially or entirely visible.
+    }
+
+    func scrollStackRowDidBecomeHidden(_ stackView: ScrollStack, row: ScrollStackRow, index: Int, state: ScrollStack.RowVisibility) {
+        // Row did become partially or entirely invisible.
+    }
+
+    func scrollStackDidUpdateLayout(_ stackView: ScrollStack) {
+        // This function is called when layout is updated (added, removed, hide or show one or more rows).
+    }
+
+    func scrollStackContentSizeDidChange(_ stackView: ScrollStack, from oldValue: CGSize, to newValue: CGSize) {
+        // This function is called when content size of the stack did change (remove/add, hide/show rows).
+    }
 }
 ```
 

--- a/Sources/ScrollStackController/ScrollStack.swift
+++ b/Sources/ScrollStackController/ScrollStack.swift
@@ -1066,6 +1066,14 @@ open class ScrollStack: UIScrollView, UIScrollViewDelegate {
         dispatchRowsVisibilityChangesTo(stackDelegate)
     }
     
+    public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        guard let stackDelegate = stackDelegate else {
+            return
+        }
+        
+        stackDelegate.scrollStackDidEndScrollingAnimation(self)
+    }
+    
     open override func layoutSubviews() {
         super.layoutSubviews()
         

--- a/Sources/ScrollStackController/Support/ScrollStack+Protocols.swift
+++ b/Sources/ScrollStackController/Support/ScrollStack+Protocols.swift
@@ -68,6 +68,11 @@ public protocol ScrollStackControllerDelegate: AnyObject {
     /// - Parameter offset: current scroll offset.
     func scrollStackDidScroll(_ stackView: ScrollStack, offset: CGPoint)
     
+    /// Tells the delegate when a scrolling animation in the scroll view concludes.
+    /// 
+    /// - Parameter stackView: The ScrollStack object that’s performing the scrolling animation.
+    func scrollStackDidEndScrollingAnimation(_ stackView: ScrollStack)
+    
     /// Row did become partially or entirely visible.
     ///
     /// - Parameter row: target row.


### PR DESCRIPTION
This PR adds a new `scrollStackDidEndScrollingAnimation(_ stackView: ScrollStack)` delegate method, so it becomes possible to know when a scrolling animation in the underlying `UIScrollView` concludes.
